### PR TITLE
GeoTIFF output

### DIFF
--- a/geomaker/db.py
+++ b/geomaker/db.py
@@ -335,7 +335,13 @@ class Polygon(DeclarativeBase):
         in_x, in_y = util.to_latlon((out_x, out_y), out_coords)
         in_x, in_y = util.from_latlon((in_x, in_y), in_coords)
 
-        return (in_x, in_y), (out_x, out_y)
+        # Compute transformation matrix in case geometry has been rectangularized
+        if mode != 'actual':
+            trf = util.transformation_matrix(a, b, c, nx, ny)
+        else:
+            trf = None
+
+        return (in_x, in_y), (out_x, out_y), trf
 
     def generate_triangulation(self, in_coords, out_coords, resolution):
         a, b, c, d, _ = self.geometry(out_coords)

--- a/geomaker/export.py
+++ b/geomaker/export.py
@@ -16,7 +16,7 @@ def has_support(fmt):
             import splipy
         elif fmt == 'stl':
             import stl
-        elif fmt in ('vtk', 'vtu'):
+        elif fmt in ('vtk', 'vtu', 'vts'):
             import vtk
     except ImportError:
         return False

--- a/geomaker/export.py
+++ b/geomaker/export.py
@@ -29,13 +29,18 @@ def supports_structured_choice(fmt):
     return fmt in ('vtk',)
 
 def is_image_format(fmt):
+    # Note: GeoTIFF is not an image format
     return fmt in ('png', 'jpeg')
+
+def requires_rectangle(fmt):
+    return is_image_format(fmt) or fmt == 'tiff'
 
 def is_structured_format(fmt):
     """Return true if FMT is inherently structured. If the format can
-    support unstructured AND structured grids, return false.
+    support unstructured AND structured grids, return false. In that
+    case, supports_structured_choice should return true.
     """
-    return is_image_format(fmt) or fmt in ('vts', 'g2')
+    return is_image_format(fmt) or fmt in ('vts', 'g2', 'tiff')
 
 
 CATEGORIZED_MAPS = [
@@ -183,16 +188,19 @@ def export(polygon, project, manager, boundary_mode='exterior',
     if not supports_texture(format):
         texture = False
     if not supports_structured_choice(format):
-        structured = is_structured_format(fmt)
-    if not image_mode:
+        structured = is_structured_format(format)
+    if not requires_rectangle(format):
         boundary_mode = 'actual'
         rotation_mode = 'none'
+
+    if format == 'tiff' and coords != 'utm33n':
+        raise ValueError('GeoTIFF output for other formats than UTM33N is not supported')
 
     manager.report_max(4 if texture else 3)
 
     manager.report_message('Generating geometry')
     if structured:
-        (in_x, in_y), (out_x, out_y) = polygon.generate_meshgrid(
+        (in_x, in_y), (out_x, out_y), trf = polygon.generate_meshgrid(
             boundary_mode, rotation_mode, in_coords=project.coords,
             out_coords=coords, resolution=resolution, maxpts=maxpts,
         )
@@ -227,7 +235,6 @@ def export(polygon, project, manager, boundary_mode='exterior',
     elif format == 'g2':
         from splipy import Surface, BSplineBasis
         from splipy.io import G2
-        print(out_x.shape, out_y.shape, data.shape)
         cpts = np.stack([out_x, out_y, data[...,0]], axis=2)
         knots = [[0.0] + list(map(float, range(n))) + [float(n-1)] for n in data.shape[:2]]
         bases = [BSplineBasis(order=2, knots=kts) for kts in knots]
@@ -275,6 +282,25 @@ def export(polygon, project, manager, boundary_mode='exterior',
         writer.SetFileName(filename)
         writer.SetInputData(grid)
         writer.Write()
+    elif format == 'tiff':
+        import tifffile
+        tifffile.imwrite(
+            filename, data[:,::-1].T,
+            extratags=[
+                # GeoKeyDirectoryTag
+                (34735, 'h', 28,
+                 (1, 1, 1, 6,             # Version and number of geo keys
+                  1024, 0, 1, 1,          # GTModelTypeGeoKey (2D projected CRS)
+                  1025, 0, 1, 1,          # GTRasterTypeGeoKey (pixels denote areas)
+                  2048, 0, 1, 4258,       # GeodeticCRSGeoKey (ETRS89)
+                  2050, 0, 1, 6258,       # GeodeticDatumGeoKey (ETRS89)
+                  2051, 0, 1, 8901,       # PrimeMeridianGeoKey (Greenwich)
+                  3072, 0, 1, 25833,      # ProjectedCRSGeoKey (ETRS89: UTM33N)
+                  ), True),
+                # ModelTransformationTag
+                (34264, 'd', 16, tuple(trf.flat), True),
+            ]
+        )
 
     manager.increment_progress()
 

--- a/geomaker/util.py
+++ b/geomaker/util.py
@@ -267,3 +267,29 @@ def bilinear_coords(x, y, w, s, rx, ry):
     il = np.floor(xl).astype(int)
     jl = np.floor(yl).astype(int)
     return xl, yl, il, jl
+
+
+def transformation_matrix(a, b, c, nx, ny):
+    """Compute a 4x4 affine transformation matrix that maps an image
+    coordinate system of size nx, ny onto the rectangle spanned by
+    lower-left corner A, top-left corner B and top-right corner C.
+    Pixels are treated as areas, and the corners are pixel centers.
+    """
+
+    A = np.array([
+        [0.5,      0.5,      1.0, 0.0,      0.0,      0.0],
+        [0.0,      0.0,      0.0, 0.5,      0.5,      1.0],
+        [nx - 0.5, 0.5,      1.0, 0.0,      0.0,      0.0],
+        [0.0,      0.0,      0.0, nx - 0.5, 0.5,      1.0],
+        [0.5,      ny - 0.5, 1.0, 0.0,      0.0,      0.0],
+        [0.0,      0.0,      0.0, 0.5,      ny - 0.5, 1.0],
+    ])
+    b = np.hstack([b, c, a])
+
+    coeffs = np.linalg.solve(A, b)
+    return np.array([
+        [coeffs[0], coeffs[1], 0.0, coeffs[2]],
+        [coeffs[3], coeffs[4], 0.0, coeffs[5]],
+        [0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ])


### PR DESCRIPTION
This PR adds support for GeoTIFF output.

GeoTIFF files are ordinary TIFF files with some added metadata. The most important metadata is the terrestrial coordinate system the data are mapped in. This PR only produces output in ETRS89 UTM zone 33 north, and contains more or less the minimal amount of metadata that prevents QGIS from complaining when opening the file.

In addition, GeoTIFF has support for an arbitrary affine transformation matrix that maps image coordinates onto terrestrial coordinates. This is useful for us, since we can generate a rectangular image that is relevant to only the region under consideration, but a sufficiently standards-compliant GeoTIFF viewer can still accurately map the data onto the terrestrial coordinate system.

In the image below I've opened a file in QGIS, which is the GeoTIFF viewer I've used to validate this PR. As you can see the image is tilted in the UTM33N coordinate system, but the actual data array in the TIFF file does not include any of the black areas.

![Screenshot from 2020-02-19 11-33-25](https://user-images.githubusercontent.com/619375/74826700-5771a500-530c-11ea-8f42-975461efd1f6.png)

CC @VikingScientist 